### PR TITLE
add examples for openshift serverless

### DIFF
--- a/openshift-serverless/alm-examples.yaml
+++ b/openshift-serverless/alm-examples.yaml
@@ -1,0 +1,48 @@
+alm-examples: |-
+  [
+    {
+      "apiVersion": "operator.knative.dev/v1beta1",
+      "kind": "KnativeServing",
+      "metadata": {
+        "name": "knative-serving"
+      },
+      "spec": {
+      }
+    },
+    {
+      "apiVersion": "operator.knative.dev/v1beta1",
+      "kind": "KnativeEventing",
+      "metadata": {
+        "name": "knative-eventing"
+      },
+      "spec": {
+      }
+    },
+    {
+      "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+      "kind": "KnativeKafka",
+      "metadata": {
+        "name": "knative-kafka"
+      },
+      "spec": {
+        "broker": {
+          "enabled": false,
+          "defaultConfig": {
+            "numPartitions": 10,
+            "replicationFactor": 3,
+            "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+          }
+        },
+        "source": {
+          "enabled": false
+        },
+        "sink": {
+          "enabled": false
+        },
+        "channel": {
+          "enabled": false,
+          "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+        }
+      }
+    }
+  ]


### PR DESCRIPTION
default alm examples that work in a regular cluster