### PR TITLE
update retries for Application sync status

### DIFF
--- a/openshift-gitops-operator/tasks/main.yml
+++ b/openshift-gitops-operator/tasks/main.yml
@@ -64,7 +64,7 @@
         kind: Application
       register: app
       until: app.resources[0].status.sync.status is defined and app.resources[0].status.sync.status == "Synced"
-      retries: 10
+      retries: 30
       delay: 10
   rescue:
     - name: Print when failed


### PR DESCRIPTION
Noticed on a fresh cluster that this timed out - probably due to needing more time to pull fresh container image.