### PR TITLE
Add amazon.aws to galaxy requirements

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -52,6 +52,7 @@ tags: []
 # range specifiers can be set and are separated by ','
 dependencies:
   kubernetes.core: '>=2.4.0'
+  amazon.aws: '>=7.0.0'
 
 # The URL of the originating SCM repository
 repository: https://github.com/opdev/fips-assessments


### PR DESCRIPTION
In order for amazon.aws collection to be pulled in when fips-assessment collection is installed, it needs to be listed in the dependencies in galaxy.yml.

Fixes #82